### PR TITLE
Get rid of set_default_language callback for User

### DIFF
--- a/admin/app/controllers/gaku/admin/users_controller.rb
+++ b/admin/app/controllers/gaku/admin/users_controller.rb
@@ -21,8 +21,9 @@ module Gaku
     end
 
     def create
-      @user = User.new(user_params)
-      @user.save
+      user_creator = UserCreator.new(user_params)
+      user_creator.save
+      @user = user_creator.get_user
       save_user_roles
       @count = User.count
       respond_with @user

--- a/admin/lib/tasks/admin_user.rake
+++ b/admin/lib/tasks/admin_user.rake
@@ -91,7 +91,8 @@ def create_admin_user
     say "\nWARNING: There is already a user with the username: #{username}, so no account changes were made.  If you wish to create an additional admin user, please run rake gaku:generate_admin again with a different username.\n\n"
   else
     say "Creating user..."
-    admin = Gaku::User.create(attributes)
+    creator = Gaku::UserCreator.new(attributes).save
+    admin = creator.get_user
     # create an admin role and and assign the admin user to that role
     role = Gaku::Role.find_or_create_by_name 'Admin'
     admin.roles << role

--- a/core/app/models/gaku/user.rb
+++ b/core/app/models/gaku/user.rb
@@ -11,8 +11,6 @@ module Gaku
 
     attr_accessor :login
 
-    before_create :default_language
-
     validates :username, presence: true, uniqueness: true
 
     roles_table_name = Role.table_name
@@ -38,16 +36,6 @@ module Gaku
 
     def role?(role)
       roles.detect {|p| p.name == role.to_s.camelize}
-    end
-
-    private
-
-    def default_language
-      if Preset.active.nil?
-        settings[:locale] = 'en'
-      else
-        settings[:locale] = Preset.active.locale['language']
-      end
     end
 
   end

--- a/core/app/services/gaku/user_creator.rb
+++ b/core/app/services/gaku/user_creator.rb
@@ -1,0 +1,31 @@
+module Gaku
+  class UserCreator
+    def initialize(params = {})
+      @user = User.new(params)
+      set_default_language
+    end
+
+    def save
+      @user.save
+    end
+
+    def save!
+      @user.save!
+    end
+
+    def get_user
+      @user
+    end
+
+    private
+
+    def set_default_language
+      if Preset.active.nil?
+        get_user.settings[:locale] = 'en'
+      else
+        get_user.settings[:locale] = Preset.active.locale['language']
+      end
+    end
+
+  end
+end

--- a/core/lib/generators/gaku/install/install_generator.rb
+++ b/core/lib/generators/gaku/install/install_generator.rb
@@ -76,6 +76,11 @@ module Gaku
       Dir.glob(File.join(File.dirname(__FILE__), "../app/overrides/*.rb")) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
+
+      # Load application's services
+      Dir.glob(File.join(File.dirname(__FILE__), "../app/services/**/*.rb")) do |c|
+        Rails.configuration.cache_classes ? require(c) : load(c)
+      end
     end
       APP
 

--- a/core/lib/tasks/admin_user.rake
+++ b/core/lib/tasks/admin_user.rake
@@ -91,7 +91,8 @@ def create_admin_user
     say "\nWARNING: There is already a user with the username: #{username}, so no account changes were made.  If you wish to create an additional admin user, please run rake gaku:generate_admin again with a different username.\n\n"
   else
     say "Creating user..."
-    admin = Gaku::User.create(attributes)
+    creator = Gaku::UserCreator.new(attributes).save
+    admin = creator.get_user
     # create an admin role and and assign the admin user to that role
     role = Gaku::Role.find_or_create_by_name 'Admin'
     admin.roles << role

--- a/core/spec/services/user_creator_spec.rb
+++ b/core/spec/services/user_creator_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper_models'
+
+describe Gaku::UserCreator do
+  describe '#initialize' do
+    it 'instantiates new User object' do
+      expect(Gaku::User).to receive(:new).with(email: 'gaku@engine.io').once.and_return(Gaku::User.new)
+      Gaku::UserCreator.new(email: 'gaku@engine.io')
+    end
+
+    context 'when there is no active preset setting' do
+      it 'sets default locale to English' do
+        allow(Gaku::Preset).to receive(:active).and_return(nil)
+        user = Gaku::UserCreator.new(email: 'gaku@engine.io').get_user
+
+        expect(user.settings[:locale]).to be == 'en'
+      end
+    end
+
+    context 'when there is existing active preset setting' do
+      it 'sets default locale to preset language' do
+        allow(Gaku::Preset).to receive(:active).and_return(OpenStruct.new(locale: { 'language' => 'de' }))
+        user = Gaku::UserCreator.new(email: 'gaku@engine.io').get_user
+
+        expect(user.settings[:locale]).to be == 'de'
+      end
+    end
+  end
+
+  describe '#save' do
+    it 'creates new user and return true' do
+      service = Gaku::UserCreator.new(username: 'gaku', email: 'gaku@engine.io', password: '123456')
+      expect { expect(service.save).to be_true }.to change { Gaku::User.count }.by(1)
+    end
+
+    context 'when failed to create' do
+      it 'does not create new user and return false' do
+        allow(Gaku::User).to receive(:valid?).and_return(false)
+        service = Gaku::UserCreator.new(username: 'gaku')
+        expect { expect(service.save).to be_false }.not_to change { Gaku::User.count }
+      end
+    end
+  end
+
+  describe '#save!' do
+    it 'creates new user and does not raise exception' do
+      service = Gaku::UserCreator.new(username: 'gaku', email: 'gaku@engine.io', password: '123456')
+      expect { expect { service.save! }.not_to raise_error }.to change { Gaku::User.count }.by(1)
+    end
+
+    context 'when failed to create' do
+      it 'does not create new user and raise exception' do
+        allow(Gaku::User).to receive(:valid?).and_return(false)
+        service = Gaku::UserCreator.new(username: 'gaku')
+        expect { expect { service.save! }.to raise_error }.not_to change { Gaku::User.count }
+      end
+    end
+  end
+end

--- a/frontend/lib/tasks/admin_user.rake
+++ b/frontend/lib/tasks/admin_user.rake
@@ -91,7 +91,8 @@ def create_admin_user
     say "\nWARNING: There is already a user with the username: #{username}, so no account changes were made.  If you wish to create an additional admin user, please run rake gaku:generate_admin again with a different username.\n\n"
   else
     say "Creating user..."
-    admin = Gaku::User.create(attributes)
+    creator = Gaku::UserCreator.new(attributes).save
+    admin = creator.get_user
     # create an admin role and and assign the admin user to that role
     role = Gaku::Role.find_or_create_by_name 'Admin'
     admin.roles << role


### PR DESCRIPTION
This would gain following:
- Make it easy for developers to extend or change the User Creation process
- Easier to create test factory and to test
