### PR TITLE
Add course spec

### DIFF
--- a/api/app/controllers/gaku/api/v1/courses/enrollments_controller.rb
+++ b/api/app/controllers/gaku/api/v1/courses/enrollments_controller.rb
@@ -6,13 +6,12 @@ module Gaku
           before_action :set_course
 
           def index
-            @enrollments = @course.enrollments.page(params[:page ])
+            @enrollments = @course.enrollments.page(params[:page])
             collection_respond_to @enrollments, root: :enrollments
-
           end
 
           def create
-            @enrollment = @course.enrollments.create(create_enrollment_params)
+            @enrollment = @course.enrollments.create!(create_enrollment_params)
             member_respond_to @enrollment
           end
 
@@ -25,18 +24,16 @@ module Gaku
           private
 
           def create_enrollment_params
-            params.require(:student_id)
-            params.permit(:student_id, :seat_number)
+            params.require(:enrollment).permit(:student_id, :seat_number)
           end
 
           def update_enrollment_params
-            params.permit(:seat_number)
+            params.require(:enrollment).permit(:seat_number)
           end
 
           def set_course
             @course = Course.find(params[:course_id])
           end
-
         end
       end
     end

--- a/api/spec/requests/course_enrollments_spec.rb
+++ b/api/spec/requests/course_enrollments_spec.rb
@@ -1,0 +1,230 @@
+require 'spec_helper_requests'
+
+describe 'Courses::Enrollments', type: :request do
+
+  let(:enrollment_attributes) {
+    %i( id student_id seat_number course_id )
+  }
+
+  let(:course) { create(:course) }
+  let(:student) { create(:student) }
+  let(:enrollment) { create(:course_enrollment) }
+  let(:course_with_enrollment) { create(:course, :with_enrollment) }
+
+  describe 'INDEX' do
+    context 'JSON' do
+      before do
+        course_with_enrollment
+        api_get gaku.api_v1_course_enrollments_path(course_with_enrollment)
+      end
+
+      it 'success response' do
+        ensure_ok
+      end
+
+      it 'assign enrollments' do
+        expect(assigns['enrollments']).to include(course_with_enrollment.enrollments.first)
+      end
+
+      it 'json attributes' do
+        expect(json['enrollments'].first).to include(*enrollment_attributes)
+      end
+
+      it 'total_count' do
+        expect(json['meta']).to include({ total_count: 1 })
+      end
+      it 'count' do
+        expect(json['meta']).to include({ count: 1 })
+      end
+      it 'page' do
+        expect(json['meta']).to include({ page: 1 })
+      end
+    end
+
+    context 'MSGPACK' do
+      before do
+        course_with_enrollment
+        msgpack_api_get gaku.api_v1_course_enrollments_path(course_with_enrollment)
+      end
+
+      it 'success response' do
+        ensure_ok
+      end
+
+      it 'assign enrollments' do
+        expect(assigns['enrollments']).to include(course_with_enrollment.enrollments.first)
+      end
+
+      it 'json attributes' do
+        expect(msgpack['enrollments'].first).to include(*enrollment_attributes)
+      end
+      it 'total_count' do
+        expect(msgpack['meta']).to include({ total_count: 1 })
+      end
+      it 'count' do
+        expect(msgpack['meta']).to include({ count: 1 })
+      end
+      it 'page' do
+        expect(msgpack['meta']).to include({ page: 1 })
+      end
+    end
+  end
+
+  describe 'CREATE' do
+    context 'JSON' do
+      describe 'success' do
+        before do
+          course
+          student
+          expect do
+            enrollment_params = { enrollment: { seat_number: 11111, student_id: student.id } }
+            api_post gaku.api_v1_course_enrollments_path(course), params: enrollment_params
+          end.to change(Gaku::Enrollment, :count).by(1)
+        end
+
+        it 'success response' do
+          ensure_ok
+        end
+
+        it 'correct enrollment attributes' do
+          expect(json).to include(seat_number: 11111)
+        end
+
+        it 'json attributes' do
+          expect(json).to include(*enrollment_attributes)
+        end
+      end
+
+      describe 'error' do
+        before do
+          course
+          api_post gaku.api_v1_course_enrollments_path(course), params: { enrollment: { student_id: nil } }
+        end
+
+        it 'render error' do
+          expect(json).to eq({ 'student_id' => ["can't be blank"] })
+        end
+
+        it 'response code' do
+          ensure_unprocessable_entity
+        end
+      end
+    end
+
+    context 'MSGPACK' do
+      describe 'success' do
+        before do
+          course
+          student
+          expect do
+            enrollment_params = { enrollment: { seat_number: 11111, student_id: student.id } }
+            msgpack_api_post gaku.api_v1_course_enrollments_path(course), msgpack: enrollment_params
+          end.to change(Gaku::Enrollment, :count).by(1)
+        end
+
+        it 'success response' do
+          ensure_ok
+        end
+
+        it 'correct enrollment attributes' do
+          expect(msgpack).to include(seat_number: 11111)
+        end
+
+        it 'msgpack attributes' do
+          expect(msgpack).to include(*enrollment_attributes)
+        end
+      end
+
+      describe 'error' do
+        before do
+          course
+          msgpack_api_post gaku.api_v1_course_enrollments_path(course), msgpack: { enrollment: { student: nil } }
+        end
+
+        it 'render error' do
+          expect(msgpack).to eq({ 'student_id' => ["can't be blank"] })
+        end
+
+        it 'response code' do
+          ensure_unprocessable_entity
+        end
+      end
+    end
+  end
+
+  describe 'UPDATE' do
+    context 'JSON' do
+      describe 'success' do
+        before do
+          enrollment
+          enrollment_params = { enrollment: { seat_number: 22222 } }
+          api_patch gaku.api_v1_course_enrollment_path(enrollment.enrollable_id, enrollment), params: enrollment_params
+        end
+
+        it 'success response' do
+          ensure_ok
+        end
+
+        it 'correct enrollment attributes' do
+          expect(json).to include(seat_number: 22222)
+        end
+
+        it 'json attributes' do
+          expect(json).to include(*enrollment_attributes)
+        end
+      end
+
+      # describe 'error' do
+      #   before do
+      #     enrollment
+      #     api_patch gaku.api_v1_course_enrollment_path(enrollment.enrollable_id, enrollment), params: { enrollment: { seat_number: nil } }
+      #   end
+      #
+      #   it 'render error' do
+      #     expect(json).to eq({ 'seat_number' => ["can't be blank"] })
+      #   end
+      #
+      #   it 'response code' do
+      #     ensure_unprocessable_entity
+      #   end
+      # end
+    end
+
+    context 'MSGPACK' do
+      describe 'success' do
+        before do
+          enrollment
+          enrollment_params = { enrollment: { seat_number: 22222 } }
+          msgpack_api_patch gaku.api_v1_course_enrollment_path(enrollment.enrollable_id, enrollment), msgpack: enrollment_params
+        end
+
+        it 'success response' do
+          ensure_ok
+        end
+
+        it 'correct enrollment attributes' do
+          expect(msgpack).to include(seat_number: 22222)
+        end
+
+        it 'msgpack attributes' do
+          expect(msgpack).to include(*enrollment_attributes)
+        end
+      end
+
+    #   describe 'error' do
+    #     before do
+    #       enrollment
+    #       msgpack_api_patch gaku.api_v1_course_erollment_path(enrollment.enrollable_id, enrollment), msgpack: { enrollment: { seat_number: '' } }
+    #     end
+    #
+    #     it 'render error' do
+    #       expect(msgpack).to eq( {'seat_number' => ["can't be blank"] })
+    #     end
+    #
+    #     it 'response code' do
+    #       ensure_unprocessable_entity
+    #     end
+    #   end
+    end
+  end
+end

--- a/api/spec/requests/course_students_spec.rb
+++ b/api/spec/requests/course_students_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper_requests'
+
+describe 'Courses::Students', type: :request do
+
+  let(:student_attributes) {
+    %i( id name surname middle_name name_reading middle_name_reading surname_reading
+      gender birth_date admitted graduated code serial_id foreign_id_code national_registration_code
+      enrollment_status_code picture_file_name picture_content_type picture_file_size
+      picture_updated_at addresses_count contacts_count notes_count courses_count guardians_count
+      external_school_records_count badges_count primary_address primary_contact class_and_number
+      user_id faculty_id commute_method_type_id scholarship_status_id created_at updated_at
+      extracurricular_activities_count class_groups_count exam_sessions_count
+    )
+  }
+
+  let(:course_with_student) { create(:course, :with_student) }
+
+  describe 'INDEX' do
+    context 'JSON' do
+      before do
+        course_with_student
+        api_get gaku.api_v1_course_students_path(course_with_student)
+      end
+
+      it 'success response' do
+        ensure_ok
+      end
+
+      it 'assign students' do
+        expect(assigns['students']).to include(course_with_student.students.first)
+      end
+
+      it 'json attributes' do
+        expect(json['students'].first).to include(*student_attributes)
+      end
+
+      it 'total_count' do
+        expect(json['meta']).to include({total_count: 1})
+      end
+      it 'count' do
+        expect(json['meta']).to include({count: 1})
+      end
+      it 'page' do
+        expect(json['meta']).to include({page: 1})
+      end
+    end
+
+    context 'MSGPACK' do
+      before do
+        course_with_student
+        msgpack_api_get gaku.api_v1_course_students_path(course_with_student)
+      end
+
+      it 'success response' do
+        ensure_ok
+      end
+
+      it 'assign students' do
+        expect(assigns['students']).to include(course_with_student.students.first)
+      end
+
+      it 'json attributes' do
+        expect(msgpack['students'].first).to include(*student_attributes)
+      end
+      it 'total_count' do
+        expect(msgpack['meta']).to include({total_count: 1})
+      end
+      it 'count' do
+        expect(msgpack['meta']).to include({count: 1})
+      end
+      it 'page' do
+        expect(msgpack['meta']).to include({page: 1})
+      end
+    end
+  end
+end

--- a/api/spec/requests/course_students_spec.rb
+++ b/api/spec/requests/course_students_spec.rb
@@ -35,13 +35,13 @@ describe 'Courses::Students', type: :request do
       end
 
       it 'total_count' do
-        expect(json['meta']).to include({total_count: 1})
+        expect(json['meta']).to include({ total_count: 1 })
       end
       it 'count' do
-        expect(json['meta']).to include({count: 1})
+        expect(json['meta']).to include({ count: 1 })
       end
       it 'page' do
-        expect(json['meta']).to include({page: 1})
+        expect(json['meta']).to include({ page: 1 })
       end
     end
 
@@ -63,13 +63,13 @@ describe 'Courses::Students', type: :request do
         expect(msgpack['students'].first).to include(*student_attributes)
       end
       it 'total_count' do
-        expect(msgpack['meta']).to include({total_count: 1})
+        expect(msgpack['meta']).to include({ total_count: 1 })
       end
       it 'count' do
-        expect(msgpack['meta']).to include({count: 1})
+        expect(msgpack['meta']).to include({ count: 1 })
       end
       it 'page' do
-        expect(msgpack['meta']).to include({page: 1})
+        expect(msgpack['meta']).to include({ page: 1 })
       end
     end
   end

--- a/core/lib/gaku/testing/factories/course_factory.rb
+++ b/core/lib/gaku/testing/factories/course_factory.rb
@@ -10,5 +10,12 @@ FactoryBot.define do
         course.save
       end
     end
+
+    trait :with_enrollement do
+      after(:create) do |course|
+        course.enrollments << create(:course_enrollment)
+        course.save
+      end
+    end
   end
 end

--- a/core/lib/gaku/testing/factories/course_factory.rb
+++ b/core/lib/gaku/testing/factories/course_factory.rb
@@ -3,5 +3,12 @@ FactoryBot.define do
     code { 'A1' }
 
     factory(:invalid_course) { code { nil } }
+
+    trait :with_student do
+      after(:create) do |course|
+        course.students << create(:student)
+        course.save
+      end
+    end
   end
 end


### PR DESCRIPTION
api/v1/coursesフォルダ内にある
enrollments
students
コントローラーのspecを追加。

なお、enrollmentsのseat_numberにバリデーションがないのが気になるけど、現コードがそうなっているので該当specをコメントアウトしてあります。